### PR TITLE
Fix compile.sh run_locally.sh

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,1 +1,5 @@
-rm -rf html/ ; cd src/game/ ; rm_olean ; cd ../../ ; make-lean-game ; cp src/game/LaTeX/implies_diag.jpg src/game/LaTeX/function_diag.jpg src/game/LaTeX/FAQ.html html/
+rm -rf html/
+rm -f src/game/**/*.olean
+make-lean-game
+
+cp src/game/LaTeX/implies_diag.jpg src/game/LaTeX/function_diag.jpg src/game/LaTeX/FAQ.html html/

--- a/run_locally.sh
+++ b/run_locally.sh
@@ -1,2 +1,1 @@
-cd html ; http-server ; cd ..
-
+python -m http.server -d html


### PR DESCRIPTION
- More readable (multiline)
- Use python http.server for running locally since that should be on everyone's systems by default
- Use globs for deleting olean artifacts since rm_olean doesn't seem to exist