### PR TITLE
Replace scripts with a Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: all
+all: html
+
+html: $(shell find src -not -name '*.olean' | sed 's/ /\\ /g')
+	$(MAKE) clean
+	make-lean-game
+	cp src/game/LaTeX/implies_diag.jpg src/game/LaTeX/function_diag.jpg src/game/LaTeX/FAQ.html html/
+	touch html
+
+.PHONY: run
+run: html
+	echo 'Ctrl+C to stop'
+	python -m http.server -d html
+
+
+.PHONY: clean
+clean:
+	rm -rf html
+	rm -rf src/game/**/*.olean

--- a/compile.sh
+++ b/compile.sh
@@ -1,5 +1,0 @@
-rm -rf html/
-rm -f src/game/**/*.olean
-make-lean-game
-
-cp src/game/LaTeX/implies_diag.jpg src/game/LaTeX/function_diag.jpg src/game/LaTeX/FAQ.html html/

--- a/run_locally.sh
+++ b/run_locally.sh
@@ -1,1 +1,0 @@
-python -m http.server -d html

--- a/ship.sh
+++ b/ship.sh
@@ -1,2 +1,0 @@
-echo "Did you remove html from hessian?"
-scph -r html


### PR DESCRIPTION
`make html` corresponds to `compile.sh` (although `make clean` is necessary to force a rebuild if make thinks that it is unnecessary) and `make run` corresponds to `run_locally.sh` (and automatically recompiles if necessary).