### PR TITLE
Use `python3` instead of just `python`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ html: $(shell find src -not -name '*.olean' | sed 's/ /\\ /g')
 .PHONY: run
 run: html
 	echo 'Ctrl+C to stop'
-	python -m http.server -d html
+	python3 -m http.server -d html
 
 
 .PHONY: clean


### PR DESCRIPTION
For some reason some people don't have it available as `python`, only `python3`.