### PR TITLE
Make some lemmas marked as [simp] for easier tuple proofs

### DIFF
--- a/src/vectors/tuple/tactics.lean
+++ b/src/vectors/tuple/tactics.lean
@@ -5,9 +5,7 @@ open tuple
 @[simp]
 lemma add_cons_eq_cons_add {n : ℕ} (u₁ v₁ : ℝ) (uₙ vₙ : tuple n)
   : (cons u₁ uₙ) + (cons v₁ vₙ) = cons (u₁ + v₁) (uₙ + vₙ) := begin
-  simp [has_add.add],
-  simp [tuple.add],
-  refl,
+  simp [has_add.add, tuple.add],
 end
 
 @[simp]

--- a/src/vectors/tuple/tactics.lean
+++ b/src/vectors/tuple/tactics.lean
@@ -9,3 +9,9 @@ lemma add_cons_eq_cons_add {n : ℕ} (u₁ v₁ : ℝ) (uₙ vₙ : tuple n)
   simp [tuple.add],
   refl,
 end
+
+@[simp]
+lemma mul_cons_eq_cons_mul {n : ℕ} (c u₁ : ℝ) (uₙ : tuple n)
+  : c ** (cons u₁ uₙ) = cons (c * u₁) (c ** uₙ) := begin
+  simp [tuple.scalar_mul, has_mul.mul, tuple.map],
+end

--- a/src/vectors/tuple/tactics.lean
+++ b/src/vectors/tuple/tactics.lean
@@ -1,0 +1,11 @@
+import vectors.tuple
+
+open tuple
+
+@[simp]
+lemma add_cons_eq_cons_add {n : ℕ} (u₁ v₁ : ℝ) (uₙ vₙ : tuple n)
+  : (cons u₁ uₙ) + (cons v₁ vₙ) = cons (u₁ + v₁) (uₙ + vₙ) := begin
+  simp [has_add.add],
+  simp [tuple.add],
+  refl,
+end


### PR DESCRIPTION
This creates two lemmas that are marked as `[simp]`, which should make proofs about tuples much easier. These lemmas are basically distribution of addition/scalar multiplication across `cons`.