### PR TITLE
Make tuples generic on the contained type

### DIFF
--- a/src/game/vector_world/level1.lean
+++ b/src/game/vector_world/level1.lean
@@ -26,12 +26,11 @@ We're going to prove that [3, 4] is a linear combination of the standard basis v
 The vector [3, 4] is a linear combination of the vectors [0, 1] and [1, 0]
 -/
 
-lemma lin_comb: ∃ (d₁ : ℝ )(d₂ : ℝ) , [[3, 4]] =  (d₁ ** [[0, 1]]) + (d₂** [[1, 0]]) :=
+lemma lin_comb: ∃ (d₁ d₂ : ℝ), [[(3 : ℝ), 4]] = (d₁ • [[0, 1]]) + (d₂ • [[1, 0]]) :=
 begin 
   use 4,
   use 3,
   simp, 
-  dsimp [scalar_mul, map, tuple.add], refl,
 end
 
 end tuple -- hide

--- a/src/game/vector_world/level10.lean
+++ b/src/game/vector_world/level10.lean
@@ -16,7 +16,7 @@ namespace tuple -- hide
 |x · y| ≤ 1 if x and y are unit vectors.
 -/
 
-lemma cauchy_schwarz_unit: ∀ {n : ℕ} (x: tuple n) (y : tuple n) 
+lemma cauchy_schwarz_unit: ∀ {n : ℕ} (x y : ℝ ^ n)
 , (norm_sq x) = 1 → (norm_sq y) = 1 → | x ⬝ y| ≤ 1 :=
 begin 
   intros n x y x_unit y_unit, 

--- a/src/game/vector_world/level11.lean
+++ b/src/game/vector_world/level11.lean
@@ -16,18 +16,17 @@ namespace tuple -- hide
 -/
 
 
-lemma norm_neg_eq_neg: ∀ {n : ℕ}  (x: tuple n)
-, (tuple.neg x).norm  = x.norm   :=
+lemma norm_neg_eq_neg: ∀ {n : ℕ} (x : ℝ ^ n)
+, ‖-x‖ = ‖x‖   :=
 begin 
-  intros n x, 
-  induction n with d hd generalizing x, 
-  cases x, 
-  simp [tuple.neg],
-  cases x, 
-  simp [tuple.neg], 
-  dsimp [tuple.norm, norm_sq, dot_product] at *, 
-  simp at *, 
-  rw hd x_tail, 
+  intros n x,
+  simp [has_norm.norm, tuple.norm, norm_sq],
+  congr' 1,
+  induction n with n hn generalizing x,
+  { cases x, refl, },
+  { cases x with n head tail,
+    simp [dot_product],
+    exact hn tail, },
 end
 
 end tuple -- hide

--- a/src/game/vector_world/level12.lean
+++ b/src/game/vector_world/level12.lean
@@ -16,11 +16,11 @@ namespace tuple -- hide
 |c|*||x|| = ||cx||
 -/
 
-lemma scalar_norm: ∀ {n : ℕ} (c : ℝ) (x: tuple n)
-,(|c| * x.norm : ℝ)  = ((c**x).norm : ℝ)   :=
+lemma scalar_norm: ∀ {n : ℕ} (c : ℝ) (x : ℝ ^ n)
+, |c| * ‖x‖ = ‖c ** x‖   :=
 begin 
   intros n c x,
-  dsimp [tuple.norm], simp,
+  simp [has_norm.norm, tuple.norm],
   have j : ∀ (x : real), (0 ≤ x) → x = real.sqrt(x * x),
   {
     intros x xgeq, 
@@ -32,8 +32,7 @@ begin
 
   have i := j c h, 
   nth_rewrite 0 i, 
-  rw ← real.sqrt_mul ,
-  dsimp [norm_sq],
+  rw ← real.sqrt_mul,
   simp [scalar_through],  
   nth_rewrite 1 dot_comm, 
   simp [scalar_through],  
@@ -80,7 +79,6 @@ begin
   }, 
   rw abs_eq_self.mpr m,
   rw ← real.sqrt_mul ,
-  dsimp [norm_sq],
   simp [scalar_through],    
   nth_rewrite 1 dot_comm, 
   simp [scalar_through], 

--- a/src/game/vector_world/level12.lean
+++ b/src/game/vector_world/level12.lean
@@ -17,7 +17,7 @@ namespace tuple -- hide
 -/
 
 lemma scalar_norm: ∀ {n : ℕ} (c : ℝ) (x : ℝ ^ n)
-, |c| * ‖x‖ = ‖c ** x‖   :=
+, |c| * ‖x‖ = ‖c • x‖   :=
 begin 
   intros n c x,
   simp [has_norm.norm, tuple.norm],

--- a/src/game/vector_world/level13.lean
+++ b/src/game/vector_world/level13.lean
@@ -16,80 +16,22 @@ namespace tuple -- hide
 -/
 
 
-#check abs_eq_self
-#check scalar_norm
-#check inv_mul_cancel
-#check real.sqrt_eq_zero
-lemma norm_zero_iff: ∀ {n : ℕ} (x: tuple n)
-, ↑(x.norm) = (0:ℝ) ↔ x = tuple.zero   :=
+lemma norm_zero_iff: ∀ {n : ℕ} (x : ℝ ^ n)
+, ‖x‖ = 0 ↔ x = 0   :=
 begin 
-  intros n x, 
-  split, 
-  {
-     dsimp [tuple.norm, norm_sq, dot_product], 
-     simp,
-     have dot_pos_def: ∀{j :ℕ} (y :tuple j), y ⬝ y = 0 →  y = tuple.zero, {
-      intro j, 
-      induction j with d hd, 
-      intro y, 
-      cases y, 
-      dsimp [tuple.zero],intro sdvdvs,  refl, 
-      intro y, 
-      cases y, 
-      dsimp [dot_product], 
-      intro q, 
-      have y_head_nonzero : y_head * y_head ≥ 0 , 
-      {
-        exact mul_self_nonneg y_head, 
-      }, 
-      have y_tail_geq : y_tail ⬝ y_tail ≥ 0, 
-      {
-        exact dot_pos_def_1 y_tail, 
-      }, 
-      have y_tail_zero : y_tail ⬝ y_tail = 0, 
-      {
-        linarith [q, y_tail_geq], 
-      }, 
-      dsimp [tuple.zero], 
-      simp, 
-      split, 
-      {
-         rw y_tail_zero at q, simp at q, 
-         assumption, 
-      }, 
-      {
-        exact hd y_tail y_tail_zero, 
-      }, 
-     }, 
-     intro h, 
-     have k := dot_pos_def_1 x, 
-     have r :=  (real.sqrt_eq_zero (dot_pos_def_1 x)).mp h, 
-     exact dot_pos_def x r, 
-  }, 
-  {
-    induction n with n ih generalizing x, 
-    {
-      intro zero, 
-      cases x, 
-      simp, 
-      dsimp [tuple.norm, norm_sq, dot_product], 
-      simp,
-    }, 
-    cases x, 
-    intro zero, 
-    dsimp [tuple.norm, norm_sq, dot_product], simp, 
-    dsimp [tuple.zero] at zero, 
-    simp at zero, 
-    cases zero with l r, 
-    rw l, rw r, simp, 
-    have k := ih x_tail r,
-    dsimp [tuple.norm] at k, simp at k,
-    dsimp [norm_sq] at k,
-    simp at k, 
-    rw ← r, rw k, 
-    simp,  
-  }, 
-  
+  intros n x,
+  simp [has_norm.norm, tuple.norm, norm_sq],
+  split,
+  { intro hx,
+    rw real.sqrt_eq_zero at hx,
+    { exact (dot_pos_def_2 x).mp hx, },
+    { exact dot_pos_def_1 x, }, },
+  { intro hx,
+    induction n with n hn,
+    { cases x, simp [dot_product], },
+    { rw hx,
+      simp [dot_product],
+      exact hn 0 rfl, }, },
 end
 
 end tuple -- hide

--- a/src/game/vector_world/level14.lean
+++ b/src/game/vector_world/level14.lean
@@ -15,30 +15,24 @@ namespace tuple -- hide
 ||(1 / ||x|| ) *x || = 1
 -/
 
-
-#check abs_eq_self
-#check scalar_norm
-#check inv_mul_cancel
-lemma div_norm_unit: ∀ {n : ℕ} (x: tuple n)
-, x ≠ tuple.zero → ↑(tuple.norm ((1 / tuple.norm x) ** x)) = (1:ℝ)   :=
+lemma div_norm_unit: ∀ {n : ℕ} (x: ℝ ^ n)
+, x ≠ 0 → ‖(1 / ‖x‖) ** x‖ = (1:ℝ) :=
 begin 
-  intros n x xneq, 
-  have i:= scalar_norm (1 / tuple.norm x) x,
-  rw ← i, 
-  simp, 
-  have j : 0 ≤ ((x.norm)⁻¹ : ℝ)   , 
-  {
-    simp, 
-  },
-  rw abs_eq_self.mpr j, 
-  apply inv_mul_cancel, 
-  have m : ↑(x.norm) = (0:ℝ) ↔ x = tuple.zero , 
-  {
-    exact norm_zero_iff x,
-  }, 
-  by_contra, 
-  have k := m.mp h, 
-  exact xneq k, 
+  intros n x xneq,
+  rw ← scalar_norm (1 / ‖x‖) x,
+  have j : 0 ≤ (1 / ‖x‖ : ℝ),
+  { simp [has_norm.norm, tuple.norm, norm_sq],
+    exact real.sqrt_nonneg _, },
+  rw abs_eq_self.mpr j,
+  simp [has_norm.norm, tuple.norm, norm_sq],
+  apply inv_mul_cancel,
+  rw real.sqrt_ne_zero,
+  { intro x_dot_0,
+    apply xneq,
+    rw ← dot_pos_def_2,
+    exact x_dot_0, },
+  { exact dot_pos_def_1 x, },
 end
 
 end tuple -- hide
+

--- a/src/game/vector_world/level14.lean
+++ b/src/game/vector_world/level14.lean
@@ -16,11 +16,11 @@ namespace tuple -- hide
 -/
 
 lemma div_norm_unit: ∀ {n : ℕ} (x: ℝ ^ n)
-, x ≠ 0 → ‖(1 / ‖x‖) ** x‖ = (1:ℝ) :=
+, x ≠ 0 → ‖ ‖x‖⁻¹ • x‖ = 1 :=
 begin 
   intros n x xneq,
-  rw ← scalar_norm (1 / ‖x‖) x,
-  have j : 0 ≤ (1 / ‖x‖ : ℝ),
+  rw ← scalar_norm (‖x‖⁻¹) x,
+  have j : 0 ≤ (‖x‖⁻¹ : ℝ),
   { simp [has_norm.norm, tuple.norm, norm_sq],
     exact real.sqrt_nonneg _, },
   rw abs_eq_self.mpr j,

--- a/src/game/vector_world/level15.lean
+++ b/src/game/vector_world/level15.lean
@@ -16,10 +16,7 @@ namespace tuple -- hide
 -/
 
 
-#check abs_eq_self
-#check scalar_norm
-#check inv_mul_cancel
-lemma zero_dot: ∀ {n : ℕ} (x : tuple n), tuple.zero ⬝ x = 0 :=
+lemma zero_dot: ∀ {n : ℕ} (x : ℝ ^ n), 0 ⬝ x = 0 :=
 begin 
    intro n , 
    induction n with d hd, 

--- a/src/game/vector_world/level16.lean
+++ b/src/game/vector_world/level16.lean
@@ -15,140 +15,90 @@ namespace tuple -- hide
 |x · y| ≤ ||x||*||y||
 -/
 
-lemma cauchy_schwarz: ∀ {n : ℕ} (x: tuple n) (y : tuple n) 
-, | x ⬝ y| ≤ x.norm *y.norm    :=
-begin 
-  intros n x y, 
-  by_cases (x= tuple.zero),
- {cases x, 
-    {dsimp [tuple.norm, norm_sq, dot_product],
-    simp, },
-    {
-      rw h, 
-      dsimp [dot_product],
-      cases y, 
-      dsimp [tuple.zero, tuple.norm, norm_sq, dot_product],
-      simp,  
-      repeat {rw zero_dot},
-      simp,  
-    },
-  }, 
-  {
-    by_cases h2 : (y = tuple.zero) , 
-    {
-      rw h2, 
-      dsimp [tuple.zero, tuple.norm, norm_sq, dot_product],
-      simp,  
-      repeat {rw zero_dot},
+lemma cauchy_schwarz: ∀ {n : ℕ} (x y : ℝ ^ n)
+, |x ⬝ y| ≤ ‖x‖ * ‖y‖    :=
+begin
+  intros n x y,
+  by_cases x_zero : x = 0,
+  { cases n,
+    { cases x, cases y,
+      simp [has_norm.norm, tuple.norm, norm_sq], },
+    { rw x_zero,
+      cases y with n head tail,
+      rw zero_dot,
+      simp [has_norm.norm, tuple.norm, norm_sq],
+      rw (dot_pos_def_2 0).mpr rfl,
+      simp, }, },
+  { by_cases y_zero : y = 0,
+    { cases n,
+      { cases x, cases y,
+        simp [has_norm.norm, tuple.norm, norm_sq], },
+      { rw y_zero,
+        cases x with n head tail,
+        rw dot_comm,
+        rw zero_dot,
+        simp [has_norm.norm, tuple.norm, norm_sq],
+        rw (dot_pos_def_2 0).mpr rfl,
+        simp, }, },
+
+    { have x_norm_pos : ‖x‖ > 0,
+      { have norm_nonzero : ‖x‖ ≠ 0,
+        { intro norm_zero,
+          apply x_zero,
+          exact (norm_zero_iff x).mp norm_zero, },
+        simp [has_norm.norm, tuple.norm, norm_sq],
+        rw lt_iff_le_and_ne,
+        split,
+        { exact dot_pos_def_1 x, },
+        { intro dot_zero,
+          apply norm_nonzero,
+          simp [has_norm.norm, tuple.norm, norm_sq],
+          rw ← dot_zero,
+          exact real.sqrt_zero, }, },
+
+      have y_norm_pos : ‖y‖ > 0,
+      { have norm_nonzero : ‖y‖ ≠ 0,
+        { intro norm_zero,
+          apply y_zero,
+          exact (norm_zero_iff y).mp norm_zero, },
+        simp [has_norm.norm, tuple.norm, norm_sq],
+        rw lt_iff_le_and_ne,
+        split,
+        { exact dot_pos_def_1 y, },
+        { intro dot_zero,
+          apply norm_nonzero,
+          simp [has_norm.norm, tuple.norm, norm_sq],
+          rw ← dot_zero,
+          exact real.sqrt_zero, }, },
+
+      have unit_dot_le_1 : |(‖x‖⁻¹ ** x) ⬝ (‖y‖⁻¹ ** y)| ≤ 1,
+      { apply cauchy_schwarz_unit,
+        { have mul_inv_unit := div_norm_unit x x_zero,
+          simp [has_norm.norm, tuple.norm] at mul_inv_unit ⊢,
+          assumption, },
+        { have mul_inv_unit := div_norm_unit y y_zero,
+          simp [has_norm.norm, tuple.norm] at mul_inv_unit ⊢,
+          assumption, }, },
+
+      have h : ‖x‖⁻¹ * ‖y‖⁻¹ * |x ⬝ y| ≤ 1 := by rwa
+        [ ← abs_eq_self.mpr (le_of_lt (inv_pos.mpr x_norm_pos))
+        , ← abs_eq_self.mpr (le_of_lt (inv_pos.mpr y_norm_pos))
+        , ← abs_mul
+        , ← abs_mul
+        , dot_comm
+        , mul_assoc
+        , ← scalar_through
+        , dot_comm
+        , ← scalar_through
+        ],
+
+      rw [ ← (one_mul ‖x‖)
+         , mul_assoc
+         , ← div_le_iff (real.mul_pos x_norm_pos y_norm_pos)
+         , div_eq_inv_mul
+         ],
       simp,
-      rw dot_comm, 
-      exact zero_dot x, 
-    } , 
-    {
-      have non_zero : x.norm > 0 ∧ y.norm > 0, 
-     {
-        split, 
-        {
-          have h5: ↑x.norm ≠ (0:ℝ)  , 
-          {
-            by_contra h3, 
-            have h4:= (norm_zero_iff x).mp h3, 
-            exact h h4,
-          }, 
-          simp at h5, 
-          have h6 := dot_pos_def_1 x,
-          exact zero_lt_iff.mpr h5,
-        }, 
-        {
-            have h5: ↑y.norm ≠ (0:ℝ)  , 
-          {
-            by_contra h3, 
-            have h4:= (norm_zero_iff y).mp h3, 
-            exact h2 h4,
-          }, 
-          simp at h5, 
-          have h6 := dot_pos_def_1 y,
-          exact zero_lt_iff.mpr h5,
-        }, 
-      }, 
-      cases non_zero with x_nonzero y_nonzero, 
-      have h3 : |((1  /  x.norm)** x) ⬝ ((1 / y.norm)** y)| ≤ 1, 
-      {
-        have h4 : x ≠ tuple.zero, 
-        {
-          exact h
-        },
-        have h5 : y ≠ tuple.zero, 
-        {
-          exact h2
-        },
-        have h6:= div_norm_unit x h4, 
-        have h7:= div_norm_unit y h5,   
-        have h9 : (1 / ↑(x.norm) ** x).norm_sq = 1, 
-        {
-          dsimp [tuple.norm] at h6,  simp at h6,
-          dsimp [tuple.norm], simp, assumption,  
-        }, 
-        have h10 : (1 / ↑(y.norm) ** y).norm_sq = 1,
-        {
-          dsimp [tuple.norm] at h7,  simp at h7,
-          dsimp [tuple.norm], simp, assumption,  
-        }, 
-        have h8:=  cauchy_schwarz_unit (1 / x.norm ** x) ( 1 / y.norm ** y) h9 h10,
-        exact h8, 
-      }, 
-      have h4 : ((1 / x.norm) : ℝ)  * |x ⬝ ((1/y.norm)** y)| ≤ 1, 
-      {
-        have h5:= scalar_through (1 / ↑(x.norm)) x (1 / ↑(y.norm) ** y),
-        rw h5 at h3, 
-        have h6 :  0 ≤ ((1 / x.norm) : ℝ) ,  
-        {
-          simp,  
-        }, 
-        have h7 := abs_mul (1 / ↑(x.norm)) (x ⬝ (1 / ↑(y.norm) ** y)), 
-        rw h7 at h3, 
-        
-        have h8 : |((1 / x.norm) : ℝ) | = (1 / x.norm : ℝ) , 
-        {
-          exact abs_eq_self.mpr h6, 
-        }, 
-        rw h8 at h3, 
-        exact h3, 
-      }, 
-      clear h3, 
-      rw dot_comm at h4, 
-      rw scalar_through at h4, 
-      rw dot_comm at h4, 
-      have h5 := abs_mul (1 / ↑y.norm) (x ⬝ y), 
-      rw h5 at h4, 
-      clear h5, 
-      have h5 : 0 ≤ ((1 / y.norm) : ℝ), 
-      {
-        simp, 
-      }, 
-      rw abs_eq_self.mpr h5 at h4,
-      have h10 : ∀ x : tuple n, x.norm = ↑ x.norm, 
-      {
-        intro x, refl, 
-      }, 
-      rw h10 at x_nonzero, 
-      rw h10 at y_nonzero,
-      clear h10,  
-      apply (@div_le_iff ℝ _ (|x ⬝ y|) (↑(y.norm)) (↑(x.norm)) y_nonzero).mp, 
-      have h6 : |x ⬝ y| / ↑(y.norm) = (1 / ↑(y.norm))* |x ⬝ y|, 
-      {
-        simp,
-        rw div_eq_inv_mul,  
-      }, 
-      rw h6, 
-      rw ← one_mul ↑ (x.norm),  
-      apply (@div_le_iff ℝ _ (1 / ↑(y.norm) * |x ⬝ y|) (↑(x.norm)) (1) x_nonzero).mp, 
-      rw div_eq_inv_mul, 
-      simp, 
-      simp at h4, 
-      exact h4,  
-    }
-  }, 
+      linarith, }, },
 end
 
 end tuple -- hide

--- a/src/game/vector_world/level16.lean
+++ b/src/game/vector_world/level16.lean
@@ -71,7 +71,7 @@ begin
           rw ← dot_zero,
           exact real.sqrt_zero, }, },
 
-      have unit_dot_le_1 : |(‖x‖⁻¹ ** x) ⬝ (‖y‖⁻¹ ** y)| ≤ 1,
+      have unit_dot_le_1 : |(‖x‖⁻¹ • x) ⬝ (‖y‖⁻¹ • y)| ≤ 1,
       { apply cauchy_schwarz_unit,
         { have mul_inv_unit := div_norm_unit x x_zero,
           simp [has_norm.norm, tuple.norm] at mul_inv_unit ⊢,

--- a/src/game/vector_world/level2.lean
+++ b/src/game/vector_world/level2.lean
@@ -30,11 +30,10 @@ We're going to prove that { [0, 1] , [1, 0] } forms a basis for ℝ²
 /- Lemma
 And vector in ℝ² can be expressed as a linear combination of the vectors [0, 1] and [1, 0]
 -/
-lemma lin_comb2: ∀  (i: ℝ) (j :ℝ ), ∃(d₁ : ℝ )(d₂ : ℝ ) , [[i, j]] =   (d₁ ** [[1, 0]]) + (d₂** [[0, 1]]) :=
+lemma lin_comb2: ∀ (i j : ℝ), ∃ (d₁ d₂ : ℝ), [[i, j]] = (d₁ • [[1, 0]]) + (d₂ • [[0, 1]]) :=
 begin 
   intros i j ,
   use [i, j],
-  dsimp [scalar_mul, map], 
   simp,
 end
 

--- a/src/game/vector_world/level3.lean
+++ b/src/game/vector_world/level3.lean
@@ -20,7 +20,7 @@ We're going to prove that the dot product is commutative!
 /- Lemma
 v ⬝ w = w ⬝ v for all vectors v, w ∈ ℝⁿ
 -/
-lemma dot_comm: ∀ {n : ℕ} (v: tuple n) (w : tuple n),  v ⬝ w = w ⬝ v :=
+lemma dot_comm: ∀ {n : ℕ} (v: ℝ ^ n) (w : ℝ ^ n),  v ⬝ w = w ⬝ v :=
 begin 
   intros n,
   induction n with d hd,

--- a/src/game/vector_world/level4.lean
+++ b/src/game/vector_world/level4.lean
@@ -25,7 +25,7 @@ We're going to prove that the dot product is positive definite!
 /- Lemma
 v ⬝ w = w ⬝ v for all vectors v, w ∈ ℝⁿ
 -/
-lemma dot_pos_def_1: ∀ {n : ℕ} (x: tuple n),  x ⬝ x ≥ 0 :=
+lemma dot_pos_def_1: ∀ {n : ℕ} (x: ℝ ^ n),  x ⬝ x ≥ 0 :=
 begin 
   intro n, 
   induction n with d hd,

--- a/src/game/vector_world/level5.lean
+++ b/src/game/vector_world/level5.lean
@@ -18,7 +18,7 @@ We're going to prove that if dot product of a vector with itself is 0 then it mu
 /- Lemma
 x ⬝ x = 0 ↔ x = tuple.zero
 -/
-lemma dot_pos_def_2: ∀ {n : ℕ} (x: tuple n),  x ⬝ x = 0 ↔ x = tuple.zero :=
+lemma dot_pos_def_2: ∀ {n : ℕ} (x : ℝ ^ n),  x ⬝ x = 0 ↔ x = 0 :=
 begin 
   intro n, 
   induction n with d hd,
@@ -44,7 +44,7 @@ begin
       linarith, 
     } , 
     {
-      dsimp [tuple.zero], simp, 
+      simp,
       rw [t_eq_zero, add_zero] at h, 
       split, 
       {

--- a/src/game/vector_world/level6.lean
+++ b/src/game/vector_world/level6.lean
@@ -14,7 +14,7 @@ namespace tuple -- hide
 (cx)·y=c (x·y) for all x, y ∈ ℝⁿ and c ∈ R
 -/
 
-lemma scalar_through: ∀ {n : ℕ} (c: ℝ) (x: ℝ ^ n) (y : ℝ ^ n) ,  (c**x) ⬝ y =c * (x ⬝ y) :=
+lemma scalar_through: ∀ {n : ℕ} (c : ℝ) (x y : ℝ ^ n), (c • x) ⬝ y = c * (x ⬝ y) :=
 begin 
   intro n,
   induction n with d hd, 
@@ -27,9 +27,10 @@ begin
     intros c x y, 
     cases x, 
     cases y, 
-    dsimp [dot_product], rw mul_add, 
+    simp,
+    rw mul_add,
     rw ← hd c x_tail y_tail,
-    dsimp [scalar_mul, map], 
+    simp,
     rw mul_assoc, 
   },
 end

--- a/src/game/vector_world/level6.lean
+++ b/src/game/vector_world/level6.lean
@@ -14,7 +14,7 @@ namespace tuple -- hide
 (cx)·y=c (x·y) for all x, y ∈ ℝⁿ and c ∈ R
 -/
 
-lemma scalar_through: ∀ {n : ℕ} (c: ℝ) (x: tuple n) (y : tuple n) ,  (c**x) ⬝ y =c * (x ⬝ y) :=
+lemma scalar_through: ∀ {n : ℕ} (c: ℝ) (x: ℝ ^ n) (y : ℝ ^ n) ,  (c**x) ⬝ y =c * (x ⬝ y) :=
 begin 
   intro n,
   induction n with d hd, 

--- a/src/game/vector_world/level7.lean
+++ b/src/game/vector_world/level7.lean
@@ -14,20 +14,20 @@ namespace tuple -- hide
 x ⬝ (y + z) = (x ⬝ y) + (x ⬝ z)
 -/
 
-lemma dot_dist: ∀ {n : ℕ} (x: tuple n) (y : tuple n) (z:tuple n)
+lemma dot_dist: ∀ {n : ℕ} (x: ℝ ^ n) (y : ℝ ^ n) (z : ℝ ^ n)
 ,  x ⬝ (y + z) = (x ⬝ y) + (x ⬝ z) :=
 begin 
   intro n,
   induction n with d hd, 
   {intros x y z, 
-  casesm* (tuple 0), 
+  casesm* (ℝ ^ 0),
   dsimp [dot_product],
   rw add_zero, 
   },
   {
     intros x y z, 
-    casesm* (tuple d.succ), 
-    dsimp [dot_product], 
+    casesm* (ℝ ^ d.succ),
+    simp [tuple.dot_product],
     have i : x_head * y_head + x_tail ⬝ y_tail + (x_head * z_head + x_tail ⬝ z_tail)
     = x_tail ⬝ y_tail + x_tail ⬝ z_tail +  x_head * y_head + x_head * z_head , 
     {

--- a/src/game/vector_world/level8.lean
+++ b/src/game/vector_world/level8.lean
@@ -14,7 +14,7 @@ namespace tuple -- hide
 ||x + y||² = ||x||² + 2 * (x ⬝ y) + ||y||²
 -/
 
-lemma add_norm_square: ∀ {n : ℕ} (x: tuple n) (y : tuple n) 
+lemma add_norm_square: ∀ {n : ℕ} (x y : ℝ ^ n)
 ,  ↑(norm_sq (x + y)) = ↑(norm_sq x) + (2 * (x ⬝ y)) + ↑(norm_sq y) :=
 begin 
   intros n x y, 

--- a/src/game/vector_world/level9.lean
+++ b/src/game/vector_world/level9.lean
@@ -1,8 +1,8 @@
 import vectors.tuple -- hide
-import vectors.tuple.group -- hide
 import data.real.basic
 import game.vector_world.level8 --hide
 import game.vector_world.neg_eq_neg_mul --hide 
+import game.vector_world.sub_eq_add_neg -- hide
 
 namespace tuple -- hide
 
@@ -25,7 +25,7 @@ begin
   rw sub_eq_add_neg,
   rw add_norm_square,
   rw neg_eq_neg_mul,
-  rw dot_comm x ((-1) ** y),
+  rw dot_comm x ((-1 : ℝ) • y),
   rw scalar_through,
   rw dot_comm y x,
   simp,

--- a/src/game/vector_world/level9.lean
+++ b/src/game/vector_world/level9.lean
@@ -18,7 +18,7 @@ namespace tuple -- hide
 -/
 
 
-lemma sub_norm_square: ∀ {n : ℕ} (x: tuple n) (y : tuple n) 
+lemma sub_norm_square: ∀ {n : ℕ} (x y : ℝ ^ n)
 ,  ↑(norm_sq (x - y)) = ↑(norm_sq x) - (2 * (x ⬝ y)) + ↑(norm_sq y) :=
 begin 
   intros n x y,
@@ -29,11 +29,10 @@ begin
   rw scalar_through,
   rw dot_comm y x,
   simp,
-  simp [tuple.norm_sq],
   rw scalar_through,
   rw dot_comm y,
   rw scalar_through,
-  linarith, 
+  linarith,
 end
 
 end tuple -- hide

--- a/src/game/vector_world/neg_eq_neg_mul.lean
+++ b/src/game/vector_world/neg_eq_neg_mul.lean
@@ -18,7 +18,7 @@ We're going to prove that if dot product of a vector with itself is 0 then it mu
 /- Lemma
 x ⬝ x = 0 ↔ x = tuple.zero
 -/
-lemma neg_eq_neg_mul : ∀ {n : ℕ} (x : ℝ ^ n),  -x = -1 ** x :=
+lemma neg_eq_neg_mul : ∀ {n : ℕ} (x : ℝ ^ n), -x = (-1 : ℝ) • x :=
 begin 
   intro n,
   induction n with n hn,

--- a/src/game/vector_world/neg_eq_neg_mul.lean
+++ b/src/game/vector_world/neg_eq_neg_mul.lean
@@ -18,7 +18,7 @@ We're going to prove that if dot product of a vector with itself is 0 then it mu
 /- Lemma
 x ⬝ x = 0 ↔ x = tuple.zero
 -/
-lemma neg_eq_neg_mul : ∀ {n : ℕ} (x: tuple n),  -x = -1 ** x :=
+lemma neg_eq_neg_mul : ∀ {n : ℕ} (x : ℝ ^ n),  -x = -1 ** x :=
 begin 
   intro n,
   induction n with n hn,

--- a/src/game/vector_world/orth_self_unique_zero.lean
+++ b/src/game/vector_world/orth_self_unique_zero.lean
@@ -16,14 +16,12 @@ namespace tuple -- hide
 **0** is the only vector orthogonal to itself
 -/
 
-lemma orth_self_unique_zero: ∀ {n : ℕ} (x: tuple n)
-,  x ⟂ x → x = tuple.zero   :=
+lemma orth_self_unique_zero: ∀ {n : ℕ} (x: ℝ ^ n)
+,  x ⟂ x → x = 0   :=
 begin 
-  intros n x,
-  intro perp, 
+  intros n x perp,
   simp at perp,
-  rw dot_pos_def_2 at perp, 
-  exact perp,  
+  rwa dot_pos_def_2 at perp,
 end
 
 end tuple

--- a/src/game/vector_world/pos_add_neg_zero.lean
+++ b/src/game/vector_world/pos_add_neg_zero.lean
@@ -18,7 +18,7 @@ We're going to prove that if dot product of a vector with itself is 0 then it mu
 /- Lemma
 x ⬝ x = 0 ↔ x = tuple.zero
 -/
-lemma add_right_neg: ∀ {n : ℕ} (x: tuple n),  x - x = 0 :=
+lemma add_right_neg : ∀ {n : ℕ} (x : ℝ ^ n), x - x = 0 :=
 begin 
   intros n,
   induction n with n hn,

--- a/src/game/vector_world/pythogoras_theorem.lean
+++ b/src/game/vector_world/pythogoras_theorem.lean
@@ -16,23 +16,21 @@ namespace tuple -- hide
 x ⟂ y iff ||x+y||² = ||x||² + ||y||²  
 -/
 
-lemma pythogaras_theorem: ∀ {n : ℕ} (x: tuple n) (y : tuple n)
-,  x ⟂ y ↔ norm_sq(x + y) = norm_sq x + norm_sq y   :=
+lemma pythogaras_theorem: ∀ {n : ℕ} (x y : ℝ ^ n)
+,  x ⟂ y ↔ (x + y).norm_sq = x.norm_sq + y.norm_sq   :=
 begin 
   intros n x y, 
   split, 
-  {
-    intro perp_xy, 
-    dsimp [norm_sq], simp, 
-    repeat {rw dot_dist}, rw dot_comm, 
-    nth_rewrite 1 dot_comm, 
-    repeat {rw dot_dist}, simp, 
-    simp at perp_xy, 
-    rw perp_xy, 
-    nth_rewrite 1 dot_comm, 
-    rw perp_xy, 
-    simp, 
-  }, 
+  { intro perp_xy,
+    simp [norm_sq],
+    have dot_right_dist : ∀ {n : ℕ} (x y z : ℝ ^ n), (y + z) ⬝ x = y ⬝ x + z ⬝ x,
+    { intros n x y z,
+      repeat {rw dot_comm _ x},
+      exact dot_dist x y z, },
+    simp [dot_dist, dot_right_dist],
+    simp at perp_xy,
+    rw perp_xy, rw dot_comm at perp_xy, rw perp_xy,
+    simp, },
   {
     intro h, 
     dsimp [norm_sq] at h, simp at *, 

--- a/src/game/vector_world/sub_eq_add_neg.lean
+++ b/src/game/vector_world/sub_eq_add_neg.lean
@@ -18,7 +18,7 @@ We're going to prove that if dot product of a vector with itself is 0 then it mu
 /- Lemma
 x ⬝ x = 0 ↔ x = tuple.zero
 -/
-lemma sub_eq_add_neg {n : ℕ} (v u : tuple n) : v - u = v + -u :=
+lemma sub_eq_add_neg {n : ℕ} (v u : ℝ ^ n) : v - u = v + -u :=
 begin 
   induction n with n hn generalizing v u,
   { cases v, cases u,

--- a/src/game/vector_world/triangle_ineq.lean
+++ b/src/game/vector_world/triangle_ineq.lean
@@ -15,8 +15,8 @@ namespace tuple -- hide
 ||x + y|| ≤ ||x|| + ||y||
 -/
 
-lemma triangle_ineq: ∀ {n : ℕ} (x: tuple n) (y : tuple n) 
-, (x + y).norm ≤ x.norm + y.norm    :=
+lemma triangle_ineq: ∀ {n : ℕ} (x: ℝ ^ n) (y : ℝ ^ n) 
+, ‖x + y‖ ≤ ‖x‖ + ‖y‖ :=
 begin 
   intros n x y, 
   have h1:= add_norm_square x y,
@@ -25,33 +25,23 @@ begin
   {
     exact le_abs_self (x ⬝ y), 
   },
-  have h4 : ↑((x + y).norm_sq) ≤ ((x.norm + y.norm)^2), 
+  have h4 : ((x + y).norm_sq) ≤ ((‖x‖₊ + ‖y‖₊)^2),
   {
-    
-    calc 
-      ↑((x + y).norm_sq) = ↑(x.norm_sq) + 2 * x ⬝ y + ↑(y.norm_sq) : 
-        begin 
-          exact h1
-        end
-      ... ≤ ↑(x.norm_sq) + 2 * |x ⬝ y| + ↑(y.norm_sq) :
-      begin 
-        linarith, 
-      end
-      ... ≤ ↑(x.norm_sq) + 2 * x.norm * y.norm + ↑(y.norm_sq) :
-      begin
-        linarith, 
-      end
-      ... =  ((x.norm + y.norm)^2) :
-      begin 
-        rw add_sq, 
-        dsimp [tuple.norm], simp, refl, 
+    calc ↑((x + y).norm_sq) = ↑(x.norm_sq) + 2 * x ⬝ y + ↑(y.norm_sq) : h1
+      ... ≤ ↑(x.norm_sq) + 2 * |x ⬝ y| + ↑(y.norm_sq) : by linarith
+      ... ≤ ↑(x.norm_sq) + 2 * ‖x‖ * ‖y‖ + ↑(y.norm_sq) : by { simp, linarith, }
+      ... =  ((‖x‖ + ‖y‖)^2) : begin
+        rw add_sq,
+        have hx_sqrt := real.sq_sqrt(dot_pos_def_1 x),
+        have hy_sqrt := real.sq_sqrt(dot_pos_def_1 y),
+        simp [norm_eq_sqrt_norm_sq, hx_sqrt, hy_sqrt],
       end
   }, 
   clear h3 h2 h1, 
-  dsimp [tuple.norm],
+  repeat { rw norm_eq_sqrt_norm_sq },
+
   have i := nnreal.sqrt_le_sqrt_iff.mpr h4, 
   rw nnreal.sqrt_sq at i,  
-  dsimp [tuple.norm] at i, 
   exact i, 
 end
 

--- a/src/game/vector_world/zero_orth_all.lean
+++ b/src/game/vector_world/zero_orth_all.lean
@@ -16,23 +16,19 @@ namespace tuple -- hide
 **0** is orthogonal to all vectors. 
 -/
 
-lemma zero_orth_all: ∀ {n : ℕ} (x: tuple n)
-,  orthogonal tuple.zero x   :=
-begin 
-  intro n, 
-  induction n with d ih, 
-  {simp,  
-  intro x, 
-  cases x, 
-  dsimp [tuple.zero, dot_product], refl, }, 
-  {
-    intro x, cases x, 
-    simp, 
-    dsimp [tuple.zero, dot_product],
-    have i:=  ih x_tail, simp at i, 
-    rw i, 
-    simp, 
-  },
+lemma zero_orth_all: ∀ {n : ℕ} (x: ℝ ^ n)
+,  orthogonal 0 x   :=
+begin
+  intro n,
+  induction n with n hn,
+  { intro x,
+    cases x,
+    simp,
+    refl, },
+  { intro x,
+    cases x with n head tail,
+    simp,
+    exact hn tail, },
 end
 
 end tuple

--- a/src/vectors/orthogonal.lean
+++ b/src/vectors/orthogonal.lean
@@ -1,8 +1,18 @@
 import vectors.tuple
 
+namespace tuple
+
+
+universe u
+variables {α : Type u} [has_add α] [has_mul α] [has_zero α]
+
+
 @[simp]
-def orthogonal {n : ℕ} (x : tuple n) (y:tuple n) : Prop :=
-x ⬝ y = 0 
+def orthogonal {n : ℕ} (x y : α ^ n) : Prop := x ⬝ y = 0
+
 
 infix ` ⟂ `:63 := orthogonal
 infix ` ⊥ `:63 := orthogonal
+
+
+end tuple

--- a/src/vectors/tuple.lean
+++ b/src/vectors/tuple.lean
@@ -113,6 +113,7 @@ end scalar_mul
 section dot_product
   variables [has_add α] [has_mul α] [has_zero α]
 
+  @[simp]
   def dot_product : ∀ {n : ℕ}, α ^ n → α ^ n → α
   | 0 _ _ := 0
   | _ (cons head₁ tail₁) (cons head₂ tail₂) := (head₁ * head₂) + dot_product tail₁ tail₂
@@ -132,6 +133,7 @@ end cross_product
 
 
 section norm_real
+  @[simp]
   def norm_sq {n : ℕ} (v : ℝ ^ n) : nnreal := ⟨v ⬝ v, begin
     induction n with n hn generalizing v,
     { cases v, refl, },

--- a/src/vectors/tuple.lean
+++ b/src/vectors/tuple.lean
@@ -11,7 +11,8 @@ inductive tuple (α : Type u) : ℕ → Type u
 | nil : tuple 0
 | cons {n : ℕ} (head : α) (tail : tuple n) : (tuple (n + 1))
 
-infix `^^`:42 := tuple
+instance : has_pow (Type u) ℕ := ⟨tuple⟩
+notation:min `(` t:79 ` ^ `:79 d:(foldl:34 ` × `:34 (n x, tuple x n) t `)` ) := d
 
 
 namespace tuple
@@ -28,60 +29,60 @@ def length {n : ℕ} : tuple α n → ℕ := n
 section repr
   variable [has_repr α]
 
-  protected meta def repr_aux : ∀ {n : ℕ}, bool → tuple α n → string
+  protected meta def repr_aux : ∀ {n : ℕ}, bool → α ^ n → string
   | 0 _ _ := ""
   | _ tt (cons a b) := repr a ++ repr_aux ff b
   | _ ff (cons a b) := ", " ++ repr a ++ repr_aux ff b
 
-  protected meta def repr : ∀ {n : ℕ}, tuple α n → string
+  protected meta def repr : ∀ {n : ℕ}, α ^ n → string
   | 0 _     := "[[]]"
   | _ (cons a b) := "[[" ++ tuple.repr_aux tt (cons a b) ++ "]]"
 
-  meta instance {n : ℕ} : has_repr (tuple α n) := ⟨tuple.repr⟩
+  meta instance {n : ℕ} : has_repr (α ^ n) := ⟨tuple.repr⟩
 end repr
 
 
 section add
   variable [has_add α]
 
-  protected def add : ∀ {n : ℕ}, tuple α n → tuple α n → tuple α n
+  protected def add : ∀ {n : ℕ}, α ^ n → α ^ n → α ^ n
   | 0 _ _ := nil
   | _ (cons head₁ tail₁) (cons head₂ tail₂) := cons (head₁ + head₂) (add tail₁ tail₂)
 
-  instance {n : ℕ} : has_add (tuple α n) := ⟨tuple.add⟩
+  instance {n : ℕ} : has_add (α ^ n) := ⟨tuple.add⟩
 end add
 
 
 section sub
   variable [has_sub α]
 
-  protected def sub [has_sub α] : ∀ {n : ℕ}, tuple α n → tuple α n → tuple α n
+  protected def sub [has_sub α] : ∀ {n : ℕ}, α ^ n → α ^ n → α ^ n
   | 0 _ _ := nil
   | _ (cons head₁ tail₁) (cons head₂ tail₂) := cons (head₁ - head₂) (sub tail₁ tail₂)
 
-  instance {n : ℕ} : has_sub (tuple α n) := ⟨tuple.sub⟩
+  instance {n : ℕ} : has_sub (α ^ n) := ⟨tuple.sub⟩
 end sub
 
 
 section zero
   variable [has_zero α]
 
-  protected def zero : ∀ {n : ℕ}, tuple α n
+  protected def zero : ∀ {n : ℕ}, α ^ n
   | 0 := [[]]
   | (n + 1) := cons 0 zero
 
-  instance {n : ℕ} : has_zero (tuple α n) := ⟨tuple.zero⟩
+  instance {n : ℕ} : has_zero (α ^ n) := ⟨tuple.zero⟩
 end zero
 
 
 section neg
   variable [has_neg α]
 
-  protected def neg : ∀ {n : ℕ}, tuple α n → tuple α n
+  protected def neg : ∀ {n : ℕ}, α ^ n → α ^ n
   | 0 _ := [[]]
   | (n + 1) (cons head tail) := cons (-head) (neg tail)
 
-  instance {n : ℕ} : has_neg (tuple α n) := ⟨tuple.neg⟩
+  instance {n : ℕ} : has_neg (α ^ n) := ⟨tuple.neg⟩
 end neg
 
 
@@ -89,11 +90,11 @@ section functor
   universe v
   variable {β : Type v}
 
-  def map : ∀ {n : ℕ}, (α → β) → tuple α n → tuple β n
+  def map : ∀ {n : ℕ}, (α → β) → α ^ n → β ^ n
   | 0 _ _ := [[]]
   | _ f (cons head tail) := cons (f head) (map f tail)
 
-  protected def map_const {n : ℕ} (x : α) : tuple β n → tuple α n := tuple.map (λ b, x)
+  protected def map_const {n : ℕ} (x : α) : β ^ n → α ^ n := tuple.map (λ b, x)
 
   --instance {n : ℕ} : functor (λ γ, tuple γ n) :=
 end functor
@@ -103,7 +104,7 @@ section scalar_mul
   variable [has_mul α]
   open has_mul
 
-  def scalar_mul {n : ℕ} (c : α) : tuple α n → tuple α n := map (mul c)
+  def scalar_mul {n : ℕ} (c : α) : α ^ n → α ^ n := map (mul c)
 
   infix ` ** `:69 := scalar_mul
 end scalar_mul
@@ -112,7 +113,7 @@ end scalar_mul
 section dot_product
   variables [has_add α] [has_mul α] [has_zero α]
 
-  def dot_product : ∀ {n : ℕ}, tuple α n → tuple α n → α
+  def dot_product : ∀ {n : ℕ}, α ^ n → α ^ n → α
   | 0 _ _ := 0
   | _ (cons head₁ tail₁) (cons head₂ tail₂) := (head₁ * head₂) + dot_product tail₁ tail₂
 
@@ -123,7 +124,7 @@ end dot_product
 section cross_product
   variables [has_add α] [has_sub α] [has_mul α]
 
-  def cross_product : tuple α 3 → tuple α 3 → tuple α 3
+  def cross_product : α ^ 3 → α ^ 3 → α ^ 3
   | [[a, b, c]] [[d, e, f]] := [[b * f - c * e, c * d - a * f, a * e - b * d]]
 
   infixl ` ×ᵥ `:74 := cross_product
@@ -131,7 +132,7 @@ end cross_product
 
 
 section norm_real
-  def norm_sq {n : ℕ} (v : tuple ℝ n) : nnreal := ⟨v ⬝ v, begin
+  def norm_sq {n : ℕ} (v : ℝ ^ n) : nnreal := ⟨v ⬝ v, begin
     induction n with n hn generalizing v,
     { cases v, refl, },
     { cases v with _ head tail,
@@ -142,24 +143,24 @@ section norm_real
       exact add_nonneg this hn, },
   end⟩
 
-  protected noncomputable def norm {n : ℕ} (v : tuple ℝ n) : nnreal := nnreal.sqrt (norm_sq v)
-  noncomputable instance {n : ℕ} : has_norm (tuple ℝ n) := ⟨coe ∘ tuple.norm⟩
-  noncomputable instance {n : ℕ} : has_nnnorm (tuple ℝ n) := ⟨tuple.norm⟩
+  protected noncomputable def norm {n : ℕ} (v : ℝ ^ n) : nnreal := nnreal.sqrt (norm_sq v)
+  noncomputable instance {n : ℕ} : has_norm (ℝ ^ n) := ⟨coe ∘ tuple.norm⟩
+  noncomputable instance {n : ℕ} : has_nnnorm (ℝ ^ n) := ⟨tuple.norm⟩
 end norm_real
 
 
 section nth
-  def nth : ∀ {n : ℕ} (i : ℕ), tuple α n → i < n → α
+  def nth : ∀ {n : ℕ} (i : ℕ), α ^ n → i < n → α
   | 0 i _ prf := absurd prf i.not_lt_zero
   | _ 0 (cons head _) prf := head
   | _ (i+1) (cons _ tail) prf := nth i (tail) (nat.le_of_succ_le_succ prf)
 
-  def update_nth : ∀ {n : ℕ} (i : ℕ), tuple α n → α → i < n → tuple α n
+  def update_nth : ∀ {n : ℕ} (i : ℕ), α ^ n → α → i < n → α ^ n
   | 0 i _ _ prf := absurd prf i.not_lt_zero
   | n 0 (cons head tail) a prf := cons a tail
   | n (i + 1) (cons head tail) a prf := cons head (update_nth i tail a (nat.le_of_succ_le_succ prf))
 
-  def remove_nth : ∀ {n : ℕ} (i : ℕ), tuple α (n + 1) → i ≤ n → tuple α n
+  def remove_nth : ∀ {n : ℕ} (i : ℕ), α ^ (n+1) → i ≤ n → α ^ n
   | 0 0 _ prf := nil
   | 0 (i + 1) _ prf := absurd prf (by linarith)
   | (n + 1) 0 (cons _ tail) prf := tail

--- a/src/vectors/tuple.lean
+++ b/src/vectors/tuple.lean
@@ -104,9 +104,9 @@ section scalar_mul
   variable [has_mul α]
   open has_mul
 
-  def scalar_mul {n : ℕ} (c : α) : α ^ n → α ^ n := map (mul c)
+  protected def smul {n : ℕ} (c : α) : α ^ n → α ^ n := map (mul c)
 
-  infix ` ** `:69 := scalar_mul
+  instance {n : ℕ} : has_smul α (α ^ n) := ⟨tuple.smul⟩
 end scalar_mul
 
 

--- a/src/vectors/tuple/group.lean
+++ b/src/vectors/tuple/group.lean
@@ -8,7 +8,7 @@ universe u
 variables {α : Type u} [add_comm_group α]
 
 
-lemma add_assoc {n : ℕ} : ∀ (u v w : tuple α n), u + v + w = u + (v + w) := begin
+lemma add_assoc {n : ℕ} : ∀ (u v w : α ^ n), u + v + w = u + (v + w) := begin
   induction n with n hn,
   { intros u v w,
     cases u, cases v, cases w,
@@ -23,7 +23,7 @@ lemma add_assoc {n : ℕ} : ∀ (u v w : tuple α n), u + v + w = u + (v + w) :=
     { exact hn uₙ vₙ wₙ, }, },
 end
 
-lemma zero_add {n : ℕ} : ∀ (v : tuple α n), 0 + v = v := begin
+lemma zero_add {n : ℕ} : ∀ (v : α ^ n), 0 + v = v := begin
   induction n with n hn,
   { intro v, cases v,
     refl, },
@@ -33,7 +33,7 @@ lemma zero_add {n : ℕ} : ∀ (v : tuple α n), 0 + v = v := begin
     exact hn tail, },
 end
 
-lemma add_zero {n : ℕ} : ∀ (v : tuple α n), v + 0 = v := begin
+lemma add_zero {n : ℕ} : ∀ (v : α ^ n), v + 0 = v := begin
   induction n with n hn,
   { intro v, cases v,
     refl, },
@@ -43,7 +43,7 @@ lemma add_zero {n : ℕ} : ∀ (v : tuple α n), v + 0 = v := begin
     exact hn tail, }
 end
 
-lemma add_comm {n : ℕ} : ∀ (u v : tuple α n), u + v = v + u := begin
+lemma add_comm {n : ℕ} : ∀ (u v : α ^ n), u + v = v + u := begin
   induction n with n hn,
   { intros u v,
     cases u, cases v,
@@ -58,17 +58,17 @@ lemma add_comm {n : ℕ} : ∀ (u v : tuple α n), u + v = v + u := begin
 end
 
 
-protected def nsmul {n : ℕ} : ℕ → tuple α n → tuple α n
+protected def nsmul {n : ℕ} : ℕ → α ^ n → α ^ n
 | 0 _ := 0
 | (n+1) v := v + nsmul n v
 
-protected lemma nsmul_zero {n : ℕ} : ∀ (v : tuple α n), (tuple.nsmul 0 v = 0) := λ v, rfl
+protected lemma nsmul_zero {n : ℕ} : ∀ (v : α ^ n), (tuple.nsmul 0 v = 0) := λ v, rfl
 
 protected lemma nsmul_succ {n : ℕ}
-  : (∀ (c : ℕ) (v : tuple α n), tuple.nsmul c.succ v = v + tuple.nsmul c v) := λ c v, rfl
+  : (∀ (c : ℕ) (v : α ^ n), tuple.nsmul c.succ v = v + tuple.nsmul c v) := λ c v, rfl
 
 
-lemma sub_eq_add_neg {n : ℕ} : (∀ (v u : tuple α n), v - u = v + -u) := begin
+lemma sub_eq_add_neg {n : ℕ} : (∀ (v u : α ^ n), v - u = v + -u) := begin
   induction n with n hn,
   { intros v u,
     cases v, cases u,
@@ -83,21 +83,21 @@ lemma sub_eq_add_neg {n : ℕ} : (∀ (v u : tuple α n), v - u = v + -u) := beg
 end
 
 
-protected def zsmul {n : ℕ} : ℤ → tuple α n → tuple α n
+protected def zsmul {n : ℕ} : ℤ → α ^ n → α ^ n
 | (int.of_nat c) := tuple.nsmul c
 | (int.neg_succ_of_nat c) := -tuple.nsmul (c+1)
 
-protected lemma zsmul_zero {n : ℕ} : ∀ (v : tuple α n), (tuple.zsmul 0 v = 0) := λ v, rfl
+protected lemma zsmul_zero {n : ℕ} : ∀ (v : α ^ n), (tuple.zsmul 0 v = 0) := λ v, rfl
 
 protected lemma zsmul_succ {n : ℕ}
-  : (∀ (c : ℕ) (v : tuple α n),
+  : (∀ (c : ℕ) (v : α ^ n),
     tuple.zsmul (int.of_nat c.succ) v = v + tuple.zsmul (int.of_nat c) v) := λ c v, rfl
 
-protected lemma zsmul_neg {n : ℕ} : (∀ (c : ℕ) (v : tuple α n),
+protected lemma zsmul_neg {n : ℕ} : (∀ (c : ℕ) (v : α ^ n),
   tuple.zsmul -[1+ c] v = -tuple.zsmul ↑(c.succ) v) := λ c v, rfl
 
 
-lemma add_left_neg {n : ℕ} : ∀ (v : tuple α n), -v + v = 0 := begin
+lemma add_left_neg {n : ℕ} : ∀ (v : α ^ n), -v + v = 0 := begin
   induction n with n hn,
   { intro v, cases v, refl, },
   { intro v,
@@ -107,7 +107,7 @@ lemma add_left_neg {n : ℕ} : ∀ (v : tuple α n), -v + v = 0 := begin
 end
 
 
-instance {n : ℕ} : add_comm_group (tuple α n) := ⟨
+instance {n : ℕ} : add_comm_group (α ^ n) := ⟨
   tuple.add,
   add_assoc,
   tuple.zero,

--- a/src/vectors/tuple/group.lean
+++ b/src/vectors/tuple/group.lean
@@ -4,8 +4,11 @@ import algebra.group.basic
 
 namespace tuple
 
+universe u
+variables {α : Type u} [add_comm_group α]
 
-lemma add_assoc {n : ℕ} : ∀ (u v w : tuple n), u + v + w = u + (v + w) := begin
+
+lemma add_assoc {n : ℕ} : ∀ (u v w : tuple α n), u + v + w = u + (v + w) := begin
   induction n with n hn,
   { intros u v w,
     cases u, cases v, cases w,
@@ -16,11 +19,11 @@ lemma add_assoc {n : ℕ} : ∀ (u v w : tuple n), u + v + w = u + (v + w) := be
     cases w with n w₁ wₙ,
     simp,
     split,
-    { ring, },
+    { exact add_assoc u₁ v₁ w₁, },
     { exact hn uₙ vₙ wₙ, }, },
 end
 
-lemma zero_add {n : ℕ} : ∀ (v : tuple n), 0 + v = v := begin
+lemma zero_add {n : ℕ} : ∀ (v : tuple α n), 0 + v = v := begin
   induction n with n hn,
   { intro v, cases v,
     refl, },
@@ -30,7 +33,7 @@ lemma zero_add {n : ℕ} : ∀ (v : tuple n), 0 + v = v := begin
     exact hn tail, },
 end
 
-lemma add_zero {n : ℕ} : ∀ (v : tuple n), v + 0 = v := begin
+lemma add_zero {n : ℕ} : ∀ (v : tuple α n), v + 0 = v := begin
   induction n with n hn,
   { intro v, cases v,
     refl, },
@@ -40,7 +43,7 @@ lemma add_zero {n : ℕ} : ∀ (v : tuple n), v + 0 = v := begin
     exact hn tail, }
 end
 
-lemma add_comm {n : ℕ} : ∀ (u v : tuple n), u + v = v + u := begin
+lemma add_comm {n : ℕ} : ∀ (u v : tuple α n), u + v = v + u := begin
   induction n with n hn,
   { intros u v,
     cases u, cases v,
@@ -50,39 +53,22 @@ lemma add_comm {n : ℕ} : ∀ (u v : tuple n), u + v = v + u := begin
     cases v with n v₁ vₙ,
     simp,
     split,
-    { ring, },
+    { exact add_comm u₁ v₁, },
     { exact hn uₙ vₙ, }, },
 end
 
 
-protected def nsmul {n : ℕ} (c : ℕ) (v : tuple n) : tuple n := ↑c ** v
+protected def nsmul {n : ℕ} : ℕ → tuple α n → tuple α n
+| 0 _ := 0
+| (n+1) v := v + nsmul n v
 
-protected lemma nsmul_zero {n : ℕ} : ∀ (v : tuple n), (tuple.nsmul 0 v = 0) := begin
-  induction n with n hn,
-  { intro v, cases v,
-    refl, },
-  { intro v,
-    cases v with n head tail,
-    simp [tuple.nsmul] at *,
-    exact hn tail, },
-end
+protected lemma nsmul_zero {n : ℕ} : ∀ (v : tuple α n), (tuple.nsmul 0 v = 0) := λ v, rfl
 
 protected lemma nsmul_succ {n : ℕ}
-  : (∀ (c : ℕ) (v : tuple n), tuple.nsmul c.succ v = v + tuple.nsmul c v) := begin
-  intro c,
-  induction n with n hn,
-  { intro v, cases v,
-    refl, },
-  { intro v,
-    cases v with n head tail,
-    simp [tuple.nsmul] at *,
-    split,
-    { ring, },
-    { exact hn tail, }, },
-end
+  : (∀ (c : ℕ) (v : tuple α n), tuple.nsmul c.succ v = v + tuple.nsmul c v) := λ c v, rfl
 
 
-lemma sub_eq_add_neg {n : ℕ} : (∀ (v u : tuple n), v - u = v + -u) := begin
+lemma sub_eq_add_neg {n : ℕ} : (∀ (v u : tuple α n), v - u = v + -u) := begin
   induction n with n hn,
   { intros v u,
     cases v, cases u,
@@ -92,52 +78,26 @@ lemma sub_eq_add_neg {n : ℕ} : (∀ (v u : tuple n), v - u = v + -u) := begin
     cases u with n u₁ uₙ,
     simp,
     split,
-    { ring, },
+    { exact sub_eq_add_neg v₁ u₁, },
     { exact hn vₙ uₙ, }, }
 end
 
 
-protected def zsmul {n : ℕ} (c : ℤ) (v : tuple n) : tuple n := ↑c ** v
+protected def zsmul {n : ℕ} : ℤ → tuple α n → tuple α n
+| (int.of_nat c) := tuple.nsmul c
+| (int.neg_succ_of_nat c) := -tuple.nsmul (c+1)
 
-protected lemma zsmul_zero {n : ℕ} : ∀ (v : tuple n), (tuple.zsmul 0 v = 0) := begin
-  induction n with n hn,
-  { intro v, cases v,
-    refl, },
-  { intro v,
-    cases v with n head tail,
-    simp [tuple.zsmul] at *,
-    exact hn tail, },
-end
+protected lemma zsmul_zero {n : ℕ} : ∀ (v : tuple α n), (tuple.zsmul 0 v = 0) := λ v, rfl
 
 protected lemma zsmul_succ {n : ℕ}
-  : (∀ (c : ℕ) (v : tuple n),
-    tuple.zsmul (int.of_nat c.succ) v = v + tuple.zsmul (int.of_nat c) v) := begin
-  intro c,
-  induction n with n hn,
-  { intro v, cases v, refl, },
-  { intro v,
-    cases v with n head tail,
-    simp [tuple.zsmul] at *,
-    split,
-    { ring, },
-    { exact hn tail, }, },
-end
+  : (∀ (c : ℕ) (v : tuple α n),
+    tuple.zsmul (int.of_nat c.succ) v = v + tuple.zsmul (int.of_nat c) v) := λ c v, rfl
 
-protected lemma zsmul_neg {n : ℕ} : (∀ (c : ℕ) (v : tuple n),
-  tuple.zsmul -[1+ c] v = -tuple.zsmul ↑(c.succ) v) := begin
-  intro c,
-  induction n with n hn,
-  { intro v, cases v, refl, },
-  { intro v,
-    cases v with n head tail,
-    simp [tuple.zsmul] at *,
-    split,
-    { ring, },
-    { exact hn tail, }, },
-end
+protected lemma zsmul_neg {n : ℕ} : (∀ (c : ℕ) (v : tuple α n),
+  tuple.zsmul -[1+ c] v = -tuple.zsmul ↑(c.succ) v) := λ c v, rfl
 
 
-lemma add_left_neg {n : ℕ} : ∀ (v : tuple n), -v + v = 0 := begin
+lemma add_left_neg {n : ℕ} : ∀ (v : tuple α n), -v + v = 0 := begin
   induction n with n hn,
   { intro v, cases v, refl, },
   { intro v,
@@ -147,7 +107,7 @@ lemma add_left_neg {n : ℕ} : ∀ (v : tuple n), -v + v = 0 := begin
 end
 
 
-instance {n : ℕ} : add_comm_group (tuple n) := ⟨
+instance {n : ℕ} : add_comm_group (tuple α n) := ⟨
   tuple.add,
   add_assoc,
   tuple.zero,

--- a/src/vectors/tuple/tactics.lean
+++ b/src/vectors/tuple/tactics.lean
@@ -8,26 +8,30 @@ variable {α : Type u}
 
 
 @[simp]
-lemma add_cons_eq_cons_add [has_add α] {n : ℕ} (u₁ v₁ : α) (uₙ vₙ : tuple α n)
+lemma add_cons_eq_cons_add [has_add α] {n : ℕ} (u₁ v₁ : α) (uₙ vₙ : α ^ n)
   : (cons u₁ uₙ) + (cons v₁ vₙ) = cons (u₁ + v₁) (uₙ + vₙ) := rfl
 
 @[simp]
-lemma sub_cons_eq_cons_sub [has_sub α] {n : ℕ} (u₁ v₁ : α) (uₙ vₙ : tuple α n)
+lemma sub_cons_eq_cons_sub [has_sub α] {n : ℕ} (u₁ v₁ : α) (uₙ vₙ : α ^ n)
   : (cons u₁ uₙ) - (cons v₁ vₙ) = cons (u₁ - v₁) (uₙ - vₙ) := rfl
 
 @[simp]
-lemma mul_cons_eq_cons_mul [has_mul α] {n : ℕ} (c head : α) (tail : tuple α n)
+lemma mul_cons_eq_cons_mul [has_mul α] {n : ℕ} (c head : α) (tail : α ^ n)
   : c ** (cons head tail) = cons (c * head) (c ** tail) := rfl
 
 @[simp]
-lemma neg_cons_eq_cons_neg [has_neg α] {n : ℕ} (head : α) (tail : tuple α n)
+lemma neg_cons_eq_cons_neg [has_neg α] {n : ℕ} (head : α) (tail : α ^ n)
   : -(cons head tail) = (cons (-head) (-tail)) := rfl
 
 @[simp]
 lemma nil_add_nil [has_add α] : (nil : tuple α 0) + nil = nil := rfl
 
 @[simp]
-lemma zero_cons [has_zero α] {n : ℕ} : (0 : tuple α n.succ) = (cons 0 0) := rfl
+lemma zero_cons [has_zero α] {n : ℕ} : (0 : α ^ n.succ) = (cons 0 0) := rfl
+
+@[simp]
+lemma eq_cons_iff_and_eq {n : ℕ} (u₁ v₁ : α) (uₙ vₙ : α ^ n)
+  : (cons u₁ uₙ) = (cons v₁ vₙ) ↔ (u₁ = v₁) ∧ (uₙ = vₙ) := by simp
 
 
 end tuple

--- a/src/vectors/tuple/tactics.lean
+++ b/src/vectors/tuple/tactics.lean
@@ -4,34 +4,38 @@ namespace tuple
 
 
 universe u
-variable {α : Type u}
+variables {α : Type u} {n : ℕ}
 
 
 @[simp]
-lemma add_cons_eq_cons_add [has_add α] {n : ℕ} (u₁ v₁ : α) (uₙ vₙ : α ^ n)
+lemma add_cons_eq_cons_add [has_add α] (u₁ v₁ : α) (uₙ vₙ : α ^ n)
   : (cons u₁ uₙ) + (cons v₁ vₙ) = cons (u₁ + v₁) (uₙ + vₙ) := rfl
 
 @[simp]
-lemma sub_cons_eq_cons_sub [has_sub α] {n : ℕ} (u₁ v₁ : α) (uₙ vₙ : α ^ n)
+lemma sub_cons_eq_cons_sub [has_sub α] (u₁ v₁ : α) (uₙ vₙ : α ^ n)
   : (cons u₁ uₙ) - (cons v₁ vₙ) = cons (u₁ - v₁) (uₙ - vₙ) := rfl
 
 @[simp]
-lemma mul_cons_eq_cons_mul [has_mul α] {n : ℕ} (c head : α) (tail : α ^ n)
+lemma mul_cons_eq_cons_mul [has_mul α] (c head : α) (tail : α ^ n)
   : c ** (cons head tail) = cons (c * head) (c ** tail) := rfl
 
 @[simp]
-lemma neg_cons_eq_cons_neg [has_neg α] {n : ℕ} (head : α) (tail : α ^ n)
+lemma neg_cons_eq_cons_neg [has_neg α] (head : α) (tail : α ^ n)
   : -(cons head tail) = (cons (-head) (-tail)) := rfl
 
 @[simp]
 lemma nil_add_nil [has_add α] : (nil : tuple α 0) + nil = nil := rfl
 
 @[simp]
-lemma zero_cons [has_zero α] {n : ℕ} : (0 : α ^ n.succ) = (cons 0 0) := rfl
+lemma zero_cons [has_zero α] : (0 : α ^ n.succ) = (cons 0 0) := rfl
 
 @[simp]
-lemma eq_cons_iff_and_eq {n : ℕ} (u₁ v₁ : α) (uₙ vₙ : α ^ n)
+lemma eq_cons_iff_and_eq (u₁ v₁ : α) (uₙ vₙ : α ^ n)
   : (cons u₁ uₙ) = (cons v₁ vₙ) ↔ (u₁ = v₁) ∧ (uₙ = vₙ) := by simp
+
+lemma cast_nnnorm_eq_norm (v : ℝ ^ n) : ↑‖v‖₊ = ‖v‖ := rfl
+lemma nnnorm_eq_sqrt_norm_sq (v : ℝ ^ n) : ‖v‖₊ = nnreal.sqrt (norm_sq v) := rfl
+lemma norm_eq_sqrt_norm_sq (v : ℝ ^ n) : ‖v‖ = ↑(nnreal.sqrt (norm_sq v)) := rfl
 
 
 end tuple

--- a/src/vectors/tuple/tactics.lean
+++ b/src/vectors/tuple/tactics.lean
@@ -3,27 +3,31 @@ import vectors.tuple
 namespace tuple
 
 
+universe u
+variable {α : Type u}
+
+
 @[simp]
-lemma add_cons_eq_cons_add {n : ℕ} (u₁ v₁ : ℝ) (uₙ vₙ : tuple n)
+lemma add_cons_eq_cons_add [has_add α] {n : ℕ} (u₁ v₁ : α) (uₙ vₙ : tuple α n)
   : (cons u₁ uₙ) + (cons v₁ vₙ) = cons (u₁ + v₁) (uₙ + vₙ) := rfl
 
 @[simp]
-lemma sub_cons_eq_cons_sub {n : ℕ} (u₁ v₁ : ℝ) (uₙ vₙ : tuple n)
+lemma sub_cons_eq_cons_sub [has_sub α] {n : ℕ} (u₁ v₁ : α) (uₙ vₙ : tuple α n)
   : (cons u₁ uₙ) - (cons v₁ vₙ) = cons (u₁ - v₁) (uₙ - vₙ) := rfl
 
 @[simp]
-lemma mul_cons_eq_cons_mul {n : ℕ} (c head : ℝ) (tail : tuple n)
+lemma mul_cons_eq_cons_mul [has_mul α] {n : ℕ} (c head : α) (tail : tuple α n)
   : c ** (cons head tail) = cons (c * head) (c ** tail) := rfl
 
 @[simp]
-lemma neg_cons_eq_cons_neg {n : ℕ} (head : ℝ) (tail : tuple n)
+lemma neg_cons_eq_cons_neg [has_neg α] {n : ℕ} (head : α) (tail : tuple α n)
   : -(cons head tail) = (cons (-head) (-tail)) := rfl
 
 @[simp]
-lemma nil_add_nil : nil + nil = nil := rfl
+lemma nil_add_nil [has_add α] : (nil : tuple α 0) + nil = nil := rfl
 
 @[simp]
-lemma zero_cons {n : ℕ} : (0 : tuple n.succ) = (cons 0 0) := rfl
+lemma zero_cons [has_zero α] {n : ℕ} : (0 : tuple α n.succ) = (cons 0 0) := rfl
 
 
 end tuple

--- a/src/vectors/tuple/tactics.lean
+++ b/src/vectors/tuple/tactics.lean
@@ -16,8 +16,11 @@ lemma sub_cons_eq_cons_sub [has_sub α] (u₁ v₁ : α) (uₙ vₙ : α ^ n)
   : (cons u₁ uₙ) - (cons v₁ vₙ) = cons (u₁ - v₁) (uₙ - vₙ) := rfl
 
 @[simp]
-lemma mul_cons_eq_cons_mul [has_mul α] (c head : α) (tail : α ^ n)
-  : c ** (cons head tail) = cons (c * head) (c ** tail) := rfl
+lemma smul_cons_eq_cons_smul [has_mul α] (c head : α) (tail : α ^ n)
+  : c • (cons head tail) = cons (c * head) (c • tail) := rfl
+
+@[simp]
+lemma smul_nil [has_mul α] (c : α) : c • (nil : tuple α 0) = nil := rfl
 
 @[simp]
 lemma neg_cons_eq_cons_neg [has_neg α] (head : α) (tail : α ^ n)


### PR DESCRIPTION
Needed for matrices since they'll be tuples of tuples.

Also adds the `R ^ n` notation (through `has_pow`) to indicate an `n`-tuple of `R` and `(R ^ n × m × w)` (etc.) to indicate higher-rank tensors (parentheses are important). Main use of the latter is for matrices (2-tensors).

This also fixes anything that depended on tuples; the game currently compiles with no warnings or errors (on my machine, at least). This has led to the simplification of some proofs that had to be rewritten.

Lastly, this also adds a couple more things to `@[simp]`; not all proofs have been updated to take advantage of this yet.