### PR TITLE
Create the cases_tuple and simpr tactics

### DIFF
--- a/src/vectors/tuple/tactics.lean
+++ b/src/vectors/tuple/tactics.lean
@@ -2,6 +2,7 @@ import vectors.tuple
 
 namespace tuple
 
+section simp
 
 universe u
 variables {α : Type u} {n : ℕ}
@@ -41,4 +42,51 @@ lemma nnnorm_eq_sqrt_norm_sq (v : ℝ ^ n) : ‖v‖₊ = nnreal.sqrt (norm_sq v
 lemma norm_eq_sqrt_norm_sq (v : ℝ ^ n) : ‖v‖ = ↑(nnreal.sqrt (norm_sq v)) := rfl
 
 
+end simp
 end tuple
+
+
+namespace tactic
+
+open lean.parser (tk small_nat ident)
+open _root_.interactive (parse)
+open _root_.interactive.types (texpr using_ident)
+open interactive («have»)
+
+
+private meta def char.to_subscript : char → char
+| '0' := '₀'
+| '1' := '₁'
+| '2' := '₂'
+| '3' := '₃'
+| '4' := '₄'
+| '5' := '₅'
+| '6' := '₆'
+| '7' := '₇'
+| '8' := '₈'
+| '9' := '₉'
+| x := x
+
+private meta def string.to_subscript (str : string) : string := ⟨char.to_subscript <$> str.to_list⟩
+
+
+meta def destruct_tuple_core (nam : name) (curr : ℕ) : tactic unit :=
+  get_local nam >>= λ e,
+    interactive.cases_core e [`_ , ↑(to_string nam ++ string.to_subscript (to_string curr)), nam]
+
+meta def destruct_tuple_recurse (nam : name) : ℕ → ℕ → tactic unit
+| 0 curr := destruct_tuple_core nam curr
+| (n+1) curr := destruct_tuple_core nam curr >> destruct_tuple_recurse n (curr+1)
+
+meta def interactive.destruct_tuple
+  (n : parse small_nat)
+  (id : parse ident)
+  (name : parse using_ident)
+  : tactic unit := do
+    let nam := name.get_or_else id,
+    rename id nam <|> tactic.fail "Hypothesis or variable not found.",
+    destruct_tuple_recurse (name.get_or_else "v") n 1 <|>
+      tactic.fail "Could not destruct tuple. Make sure that it is of the correct type."
+
+
+end tactic

--- a/src/vectors/tuple/tactics.lean
+++ b/src/vectors/tuple/tactics.lean
@@ -79,13 +79,13 @@ meta def destruct_tuple_recurse (nam : name) : ℕ → ℕ → tactic unit
 | (n+1) curr := destruct_tuple_core nam curr >> destruct_tuple_recurse n (curr+1)
 
 meta def interactive.destruct_tuple
-  (n : parse small_nat)
   (id : parse ident)
+  (n : parse small_nat)
   (name : parse using_ident)
   : tactic unit := do
     let nam := name.get_or_else id,
     rename id nam <|> tactic.fail "Hypothesis or variable not found.",
-    destruct_tuple_recurse (name.get_or_else "v") n 1 <|>
+    destruct_tuple_recurse nam n 1 <|>
       tactic.fail "Could not destruct tuple. Make sure that it is of the correct type."
 
 

--- a/src/vectors/tuple/tactics.lean
+++ b/src/vectors/tuple/tactics.lean
@@ -70,23 +70,23 @@ private meta def char.to_subscript : char → char
 private meta def string.to_subscript (str : string) : string := ⟨char.to_subscript <$> str.to_list⟩
 
 
-meta def destruct_tuple_core (nam : name) (curr : ℕ) : tactic unit :=
+meta def cases_tuple_core (nam : name) (curr : ℕ) : tactic unit :=
   get_local nam >>= λ e,
     interactive.cases_core e [`_ , ↑(to_string nam ++ string.to_subscript (to_string curr)), nam]
 
-meta def destruct_tuple_recurse (nam : name) : ℕ → ℕ → tactic unit
-| 0 curr := destruct_tuple_core nam curr
-| (n+1) curr := destruct_tuple_core nam curr >> destruct_tuple_recurse n (curr+1)
+meta def cases_tuple_recurse (nam : name) : ℕ → ℕ → tactic unit
+| 0 curr := cases_tuple_core nam curr
+| (n+1) curr := cases_tuple_core nam curr >> cases_tuple_recurse n (curr+1)
 
-meta def interactive.destruct_tuple
+meta def interactive.cases_tuple
   (id : parse ident)
   (n : parse small_nat)
   (name : parse using_ident)
   : tactic unit := do
     let nam := name.get_or_else id,
     rename id nam <|> tactic.fail "Hypothesis or variable not found.",
-    destruct_tuple_recurse nam n 1 <|>
-      tactic.fail "Could not destruct tuple. Make sure that it is of the correct type."
+    cases_tuple_recurse nam n 1 <|>
+      tactic.fail "Could not cases tuple. Make sure that it is of the correct type."
 
 
 end tactic

--- a/src/vectors/tuple/tactics.lean
+++ b/src/vectors/tuple/tactics.lean
@@ -49,8 +49,8 @@ end tuple
 namespace tactic
 
 open lean.parser (tk small_nat ident)
-open _root_.interactive (parse)
-open _root_.interactive.types (texpr using_ident)
+open _root_.interactive
+open _root_.interactive.types
 open interactive («have»)
 
 
@@ -87,6 +87,13 @@ meta def interactive.cases_tuple
     rename id nam <|> tactic.fail "Hypothesis or variable not found.",
     cases_tuple_recurse nam n 1 <|>
       tactic.fail "Could not cases tuple. Make sure that it is of the correct type."
+
+
+meta def interactive.simpr (use_iota_eqn : parse $ optional (tk "!"))
+  (trace_lemmas : parse $ optional (tk "?")) (no_dflt : parse only_flag) (hs : parse simp_arg_list)
+  (attr_names : parse with_ident_list) (locat : parse location) (cfg : simp_config_ext := {})
+  : tactic unit :=
+  interactive.simp use_iota_eqn trace_lemmas no_dflt hs attr_names locat cfg  >> interactive.refl
 
 
 end tactic


### PR DESCRIPTION
### `cases_tuple`

Effectively, for `v : a ^ n` for `n <= m`, then running
```lean
cases_tuple v m using w,
```
will perform `cases` on `v` a total of `m` times, naming each element as `w_x` where `x` is the appropriate index and `_x` is the subscript form of `x`. The tail, if any, will be called `w`. Omitting the `using w` will default to using the current name (`v`) as the prefix.

Proper documentation is still necessary, but this is in a working state now. Ideally it would be possible to make it automatically infer the value of `m` as being `n`, but I cannot figure out how to do that currently.

### `simpr`
`simp` + `refl`. Fwds all arguments to `simp`. Fails if either `simp` or `refl` fail.